### PR TITLE
Update GitHub Actions workflow for README updates

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feature/automate-readme-update
+      - main
 
 jobs:
   update-readme:
@@ -27,9 +27,11 @@ jobs:
         run: python update_readme.py
 
       - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add README.md
           git commit -m 'Update README with latest badges' || echo "No changes to commit"
-          git push
+          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} HEAD:${{ github.ref }}

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -32,8 +32,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add README.md
           git commit -m 'Update README with latest badges' || echo "No changes to commit"
           git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} HEAD:${{ github.ref }}

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
 jobs:
   update-readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To solved the error: 403 "remote: Permission to Adminrivero/Adminrivero.git denied to github-actions[bot]."

1. Enable Write Permissions for GITHUB_TOKEN: Go to your repository’s
Settings → Actions → General → Workflow permissions and select
[X] Read and write permissions.

2. Update the workflow YAML so the push command uses the token securely for authentication.