### PR TITLE
fix(readme): Preserve horizontal Credly badge layout in GitHub profil…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ I'm a firm believer in continuous learning and am deeply fascinated by the trans
 
 ## 🏅 Badges
 
+<div style="display:inline-flex; flex-wrap: wrap; gap: 5px; align-items: center; margin-bottom: 20px;" align="center">
 <!--START_SECTION:badges-->
 <a href="https://www.credly.com/badges/ffaca78c-4f5c-434f-8d3a-53caf2ae0445" title="CS50P: Introduction to Programming with Python"><img src="./res/badges/cs50p_badge.png" alt="CS50P: Introduction to Programming with Python" width="90" height="80" style="margin-right: 5px;"></a>
 <a href="https://www.credly.com/badges/8c39f365-6989-4f17-8a4d-dff21b16fb8c" title="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer"><img src="https://images.credly.com/images/4e248e82-9e87-4a63-9263-250fafe5fb1f/image.png" alt="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer" width="80" height="80" style="margin-right: 5px;"></a>
@@ -90,6 +91,7 @@ I'm a firm believer in continuous learning and am deeply fascinated by the trans
 <a href="https://www.credly.com/badges/0678c1fc-3e59-4be2-98e9-80ed7adc9b38" title="Generative AI for Software Developers Specialization"><img src="https://images.credly.com/images/e41c77a7-4668-44e4-a196-008235304a3d/image.png" alt="Generative AI for Software Developers Specialization" width="80" height="80" style="margin-right: 5px;"></a>
 <a href="https://www.credly.com/badges/a6e7c376-5d1d-4c73-b3af-1ea6d567e857" title="Generative AI: Prompt Engineering"><img src="https://images.credly.com/images/7fd5a03e-823f-4449-af43-59afe528f4ee/image.png" alt="Generative AI: Prompt Engineering" width="80" height="80" style="margin-right: 5px;"></a>
 <!--END_SECTION:badges-->
+</div>
 
 > Find all my badges on [Credly.com](https://www.credly.com/users/hector-rafael-rivero-marquez/badges)
 


### PR DESCRIPTION

This pull request makes a small improvement to the `README.md` by adding a styled `<div>` around the badges section to enhance its layout and alignment.