### PR TITLE
Fix/readme badge layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ I'm a firm believer in continuous learning and am deeply fascinated by the trans
 
 ## 🏅 Badges
 
-<p align="center">
+<p align="left">
 <!--START_SECTION:badges-->
 <a href="https://www.credly.com/badges/ffaca78c-4f5c-434f-8d3a-53caf2ae0445" title="CS50P: Introduction to Programming with Python"><img src="./res/badges/cs50p_badge.png" alt="CS50P: Introduction to Programming with Python" width="90" height="80" style="margin-right: 5px;"></a>
 <a href="https://www.credly.com/badges/8c39f365-6989-4f17-8a4d-dff21b16fb8c" title="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer"><img src="https://images.credly.com/images/4e248e82-9e87-4a63-9263-250fafe5fb1f/image.png" alt="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer" width="80" height="80" style="margin-right: 5px;"></a>

--- a/scripts/badges/credly_badge_fetcher.py
+++ b/scripts/badges/credly_badge_fetcher.py
@@ -57,8 +57,8 @@ def extract_badges_html(json_data):
             
             # Generate HTML snippet
             html += (
-                f'<a href="{badge_url}" title="{badge_name}">'
-                f'<img src="{image_url}" alt="{badge_name}" width="{width}" height="{height}" style="margin-right: 5px;">'
+                f'<a href="{badge_url}" title="{badge_name}" style="display:inline-block; margin: 0 5px 5px 0;">'
+                f'<img src="{image_url}" alt="{badge_name}" width="{width}" height="{height}">'
                 f'</a>\n'
             )
         except KeyError as e:


### PR DESCRIPTION
This pull request makes minor improvements to the display and formatting of badges in the project. The most important changes are:

**Badge alignment and layout:**

* Changed the badge container alignment in `README.md` from center to left for improved readability.

**Badge HTML generation:**

* Updated the badge HTML snippet in `scripts/badges/credly_badge_fetcher.py` to add inline-block display and margin styles to the anchor tag, and removed the margin from the image tag for more consistent badge spacing.