### PR TITLE
Fix/readme badge table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ I'm a firm believer in continuous learning and am deeply fascinated by the trans
 
 ## 🏅 Badges
 
-<p align="left">
+<table align="left"><tr>
 <!--START_SECTION:badges-->
 <a href="https://www.credly.com/badges/ffaca78c-4f5c-434f-8d3a-53caf2ae0445" title="CS50P: Introduction to Programming with Python" style="display:inline-block; margin: 0 5px 5px 0;"><img src="./res/badges/cs50p_badge.png" alt="CS50P: Introduction to Programming with Python" width="90" height="80"></a>
 <a href="https://www.credly.com/badges/8c39f365-6989-4f17-8a4d-dff21b16fb8c" title="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer" style="display:inline-block; margin: 0 5px 5px 0;"><img src="https://images.credly.com/images/4e248e82-9e87-4a63-9263-250fafe5fb1f/image.png" alt="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer" width="80" height="80"></a>
@@ -91,7 +91,7 @@ I'm a firm believer in continuous learning and am deeply fascinated by the trans
 <a href="https://www.credly.com/badges/0678c1fc-3e59-4be2-98e9-80ed7adc9b38" title="Generative AI for Software Developers Specialization" style="display:inline-block; margin: 0 5px 5px 0;"><img src="https://images.credly.com/images/e41c77a7-4668-44e4-a196-008235304a3d/image.png" alt="Generative AI for Software Developers Specialization" width="80" height="80"></a>
 <a href="https://www.credly.com/badges/a6e7c376-5d1d-4c73-b3af-1ea6d567e857" title="Generative AI: Prompt Engineering" style="display:inline-block; margin: 0 5px 5px 0;"><img src="https://images.credly.com/images/7fd5a03e-823f-4449-af43-59afe528f4ee/image.png" alt="Generative AI: Prompt Engineering" width="80" height="80"></a>
 <!--END_SECTION:badges-->
-</p>
+</tr></table>
 
 > Find all my badges on [Credly.com](https://www.credly.com/users/hector-rafael-rivero-marquez/badges)
 

--- a/scripts/badges/credly_badge_fetcher.py
+++ b/scripts/badges/credly_badge_fetcher.py
@@ -56,10 +56,17 @@ def extract_badges_html(json_data):
             badge_url = f"https://www.credly.com/badges/{badge_id}"
             
             # Generate HTML snippet
+            # html += (
+            #     f'<a href="{badge_url}" title="{badge_name}" style="display:inline-block; margin: 0 5px 5px 0;">'
+            #     f'<img src="{image_url}" alt="{badge_name}" width="{width}" height="{height}">'
+            #     f'</a>\n'
+            # )
             html += (
-                f'<a href="{badge_url}" title="{badge_name}" style="display:inline-block; margin: 0 5px 5px 0;">'
+                f'<td style="padding: 5px; text-align: center;">'
+                f'<a href="{badge_url}" title="{badge_name}">'
                 f'<img src="{image_url}" alt="{badge_name}" width="{width}" height="{height}">'
-                f'</a>\n'
+                f'</a>'
+                f'</td>\n'
             )
         except KeyError as e:
             print(f"Skipping badge due to missing key: {e}")


### PR DESCRIPTION
This pull request updates the way badges are displayed in the `README.md` and the HTML generation logic in the badge fetcher script to improve badge layout and presentation. The main change is switching from a paragraph-based badge layout to a table-based layout, making badges appear more organized and visually appealing.

**Badge display and layout improvements:**

* Changed the badges section in `README.md` from a `<p>` (paragraph) layout to a `<table>` layout, wrapping badge images in table cells for better alignment and presentation.
* Updated the `extract_badges_html` function in `scripts/badges/credly_badge_fetcher.py` to generate badge HTML as `<td>` (table cell) elements containing the badge links and images, instead of inline anchor tags. This supports the new table-based layout in the README.