### PR TITLE
fix: Remove borders from Credly badge table layout in profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ I'm a firm believer in continuous learning and am deeply fascinated by the trans
 
 ## 🏅 Badges
 
-<table align="left"><tr>
+<table style="border-collapse: collapse; border: none;"><tr>
 <!--START_SECTION:badges-->
 <a href="https://www.credly.com/badges/ffaca78c-4f5c-434f-8d3a-53caf2ae0445" title="CS50P: Introduction to Programming with Python" style="display:inline-block; margin: 0 5px 5px 0;"><img src="./res/badges/cs50p_badge.png" alt="CS50P: Introduction to Programming with Python" width="90" height="80"></a>
 <a href="https://www.credly.com/badges/8c39f365-6989-4f17-8a4d-dff21b16fb8c" title="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer" style="display:inline-block; margin: 0 5px 5px 0;"><img src="https://images.credly.com/images/4e248e82-9e87-4a63-9263-250fafe5fb1f/image.png" alt="[PCAP-31-03] PCAP™ – Certified Associate Python Programmer" width="80" height="80"></a>

--- a/scripts/badges/credly_badge_fetcher.py
+++ b/scripts/badges/credly_badge_fetcher.py
@@ -62,7 +62,7 @@ def extract_badges_html(json_data):
             #     f'</a>\n'
             # )
             html += (
-                f'<td style="padding: 5px; text-align: center;">'
+                f'<td style="border: none; padding: 0 5px 5px 0; text-align: center;">'
                 f'<a href="{badge_url}" title="{badge_name}">'
                 f'<img src="{image_url}" alt="{badge_name}" width="{width}" height="{height}">'
                 f'</a>'


### PR DESCRIPTION
This pull request makes minor improvements to the display of badges in both the `README.md` file and the badge generation script. The main focus is on enhancing the visual appearance and consistency of badge tables by adjusting table and cell styles.

Badge display improvements:

* Updated the `<table>` tag in `README.md` to use inline CSS for borderless and collapsed table formatting, improving the overall appearance of the badges section.
* Modified the `<td>` style in the `extract_badges_html` function in `scripts/badges/credly_badge_fetcher.py` to remove borders and adjust padding, ensuring better alignment and spacing for badge images.